### PR TITLE
fix: Make db functions reactive

### DIFF
--- a/.changeset/nine-geese-clean.md
+++ b/.changeset/nine-geese-clean.md
@@ -1,0 +1,5 @@
+---
+'svelte-instantdb': patch
+---
+
+Make db functions accept reactive values

--- a/src/lib/InstantSvelteWeb.ts
+++ b/src/lib/InstantSvelteWeb.ts
@@ -1,8 +1,8 @@
-import { i, type RoomSchemaShape } from '@instantdb/core';
+import type { InstantGraph, RoomSchemaShape } from '@instantdb/core';
 import { InstantSvelte } from './InstantSvelte.js';
 
 export class InstantSvelteWeb<
-	Schema extends i.InstantGraph<any, any> | {} = {},
+	Schema extends InstantGraph<any, any> | {} = {},
 	RoomSchema extends RoomSchemaShape = {},
 	WithCardinalityInference extends boolean = false
 > extends InstantSvelte<Schema, RoomSchema, WithCardinalityInference> {}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,7 +14,21 @@ import {
 	type AuthState,
 	type Query,
 	type Config,
-	type InstaQLQueryParams
+	type InstaQLQueryParams,
+
+	// schema types
+	type AttrsDefs,
+	type CardinalityKind,
+	type DataAttrDef,
+	type EntitiesDef,
+	type EntitiesWithLinks,
+	type EntityDef,
+	type InstantGraph,
+	type LinkAttrDef,
+	type LinkDef,
+	type LinksDef,
+	type ResolveAttrs,
+	type ValueTypes
 } from '@instantdb/core';
 
 import { InstantSvelte } from './InstantSvelte.js';
@@ -45,5 +59,19 @@ export {
 	type InstantQuery,
 	type InstantQueryResult,
 	type InstantSchema,
-	type InstaQLQueryParams
+	type InstaQLQueryParams,
+
+	// schema types
+	type AttrsDefs,
+	type CardinalityKind,
+	type DataAttrDef,
+	type EntitiesDef,
+	type EntitiesWithLinks,
+	type EntityDef,
+	type InstantGraph,
+	type LinkAttrDef,
+	type LinkDef,
+	type LinksDef,
+	type ResolveAttrs,
+	type ValueTypes
 };

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,8 +1,8 @@
-import {
+import type {
 	// types
-	type Config,
-	i,
-	type RoomSchemaShape
+	Config,
+	InstantGraph,
+	RoomSchemaShape
 } from '@instantdb/core';
 import { InstantSvelteWeb } from './InstantSvelteWeb.js';
 
@@ -31,7 +31,7 @@ export function init<Schema = {}, RoomSchema extends RoomSchemaShape = {}>(confi
 }
 
 export function init_experimental<
-	Schema extends i.InstantGraph<any, any, any>,
+	Schema extends InstantGraph<any, any, any>,
 	WithCardinalityInference extends boolean = true
 >(
 	config: Config & {
@@ -41,7 +41,7 @@ export function init_experimental<
 ) {
 	return new InstantSvelteWeb<
 		Schema,
-		Schema extends i.InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never,
+		Schema extends InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never,
 		WithCardinalityInference
 	>(config);
 }

--- a/src/lib/runes/index.ts
+++ b/src/lib/runes/index.ts
@@ -1,1 +1,1 @@
-export { toStateRune } from './store.svelte.js'
+export { toStateRune } from './store.svelte.js';

--- a/src/lib/runes/store.svelte.ts
+++ b/src/lib/runes/store.svelte.ts
@@ -3,17 +3,17 @@ import { type Readable, get } from 'svelte/store';
 type ReadableValue<T> = T extends Readable<infer U> ? U : never;
 
 export function toStateRune<T extends Readable<unknown>>(store: T) {
-  let current = $state(get(store) as ReadableValue<T>)
+	let current = $state(get(store) as ReadableValue<T>);
 
-  $effect.pre(() => {
+	$effect.pre(() => {
 		return store.subscribe((v) => {
 			current = v as ReadableValue<T>;
 		});
 	});
 
-  return {
-    get current() {
-      return current
-    }
-  }
+	return {
+		get current() {
+			return current;
+		}
+	};
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,11 +16,17 @@
 
 	const db = init<Schema>({ appId: APP_ID });
 
-	let q = {
-		todos: {}
-	};
+	let todoId = '9cd88cf8-e2ac-45df-b683-ba7a025cd8dc';
 
-	$: state = db.useQuery(q);
+	$: state = db.useQuery({
+		todos: {
+			$: {
+				where: {
+					id: todoId
+				}
+			}
+		}
+	});
 
 	let newTodo = '';
 
@@ -48,15 +54,12 @@
 	</form>
 	<button
 		on:click={() => {
-			q = {
-				todos: {
-					$: {
-						where: {
-							id: 'b20de635-b9ab-4cd6-ad24-366be1304bcf'
-						}
-					}
-				}
-			};
+			const ids = [
+				'8877544a-6c99-41a4-85bf-328fa5cc3435',
+				'3a938523-2db8-4ecd-8dc6-59a3453bf7d2',
+				'6d0d8e51-702d-4f3b-bfb2-a0298c41f54a'
+			];
+			todoId = ids[Math.floor(Math.random() * ids.length)];
 		}}>Update q</button
 	>
 	<ul>
@@ -64,4 +67,5 @@
 			<li>{todo.text} - {todo.createdAt}</li>
 		{/each}
 	</ul>
+	<a href="/cursors">Cursors page</a>
 {/if}

--- a/src/routes/runes/+page.svelte
+++ b/src/routes/runes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { init, tx, id } from '$lib/index.js';
 	import { env } from '$env/dynamic/public';
-	import { toStateRune } from '$lib/runes/index.js'
+	import { toStateRune } from '$lib/runes/index.js';
 
 	const APP_ID = env.PUBLIC_INSTANT_APP_ID;
 


### PR DESCRIPTION
This will make returned data from some db functions reactive. Example usage:

```svelte
<script>
let todoId = '9cd88cf8-e2ac-45df-b683-ba7a025cd8dc'

$: state = db.useQuery({
	todos: {
		$: {
			where: {
				id: todoId
			}
		}
	}
});

todoId = '8877544a-6c99-41a4-85bf-328fa5cc3435' // state will have new values
</script>
```